### PR TITLE
Add weekly quote feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,17 @@
       }
       .frame { position: absolute; border: 2px solid #333; background: #fff; box-sizing: border-box; }
       .frame .resizer { width: 10px; height: 10px; background: #333; position: absolute; right: 0; bottom: 0; cursor: se-resize; }
+      .weekly-quote {
+        position: fixed;
+        bottom: 10px;
+        right: 10px;
+        color: #ffffff;
+        background: rgba(0, 0, 0, 0.5);
+        padding: 8px 12px;
+        font-style: italic;
+        font-size: 14px;
+        border-radius: 4px;
+      }
     </style>
     <script>
       function updateDateTime() {
@@ -51,6 +62,9 @@
       function init() {
         updateDateTime();
         setInterval(updateDateTime, 60000);
+        updateQuote();
+        // refresh quote once a day
+        setInterval(updateQuote, 86400000);
         google.script.run.withSuccessHandler(updateWeather).getWeather();
         google.script.run.withSuccessHandler(loadFrames).getFrames();
         document.getElementById('add-frame').addEventListener('click', addFrame);
@@ -58,6 +72,26 @@
 
       var frames = [];
       var zIndex = 1;
+
+      function getWeeklyQuote() {
+        var quotes = [
+          "Believe you can and you're halfway there. — Theodore Roosevelt",
+          "The only way to do great work is to love what you do. — Steve Jobs",
+          "Hardships often prepare ordinary people for an extraordinary destiny. — C.S. Lewis",
+          "Success is not final, failure is not fatal: it is the courage to continue that counts. — Winston Churchill",
+          "You miss 100% of the shots you don't take. — Wayne Gretzky"
+        ];
+        var startDate = new Date('2025-06-08');
+        var now = new Date();
+        var diff = now - startDate;
+        var week = Math.floor(diff / (7 * 24 * 60 * 60 * 1000));
+        var index = ((week % quotes.length) + quotes.length) % quotes.length;
+        return quotes[index];
+      }
+
+      function updateQuote() {
+        document.getElementById('weekly-quote').textContent = getWeeklyQuote();
+      }
 
       function loadFrames(data) {
         frames = data || [];
@@ -177,5 +211,6 @@
       </div>
     </div>
     <div id="viewing-area" class="viewing-area"></div>
+    <div id="weekly-quote" class="weekly-quote"></div>
   </body>
 </html>

--- a/quotes.js
+++ b/quotes.js
@@ -1,0 +1,16 @@
+function getWeeklyQuote(date = new Date()) {
+  const quotes = [
+    "Believe you can and you're halfway there. — Theodore Roosevelt",
+    "The only way to do great work is to love what you do. — Steve Jobs",
+    "Hardships often prepare ordinary people for an extraordinary destiny. — C.S. Lewis",
+    "Success is not final, failure is not fatal: it is the courage to continue that counts. — Winston Churchill",
+    "You miss 100% of the shots you don't take. — Wayne Gretzky"
+  ];
+  const startDate = new Date('2025-06-08');
+  const diffMs = date - startDate;
+  const week = Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000));
+  const index = ((week % quotes.length) + quotes.length) % quotes.length;
+  return quotes[index];
+}
+
+module.exports = { getWeeklyQuote };

--- a/tests/quotes.test.js
+++ b/tests/quotes.test.js
@@ -1,0 +1,12 @@
+const { getWeeklyQuote } = require('../quotes');
+
+test('cycles through quotes based on week difference', () => {
+  const start = new Date('2025-06-08');
+  const quote1 = getWeeklyQuote(new Date(start));
+  const quote2 = getWeeklyQuote(new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000));
+  const quote3 = getWeeklyQuote(new Date(start.getTime() + 2 * 7 * 24 * 60 * 60 * 1000));
+  expect(quote1).not.toBeFalsy();
+  expect(quote2).not.toBeFalsy();
+  expect(quote3).not.toBeFalsy();
+  expect(quote1).not.toEqual(quote2); // ensures rotation
+});


### PR DESCRIPTION
## Summary
- display a weekly inspirational quote at the bottom-right
- rotate quotes every week from a fixed list
- expose quote logic for testing
- test weekly quote selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684521f4e6d48322b6be2e983232f7cb