### PR TITLE
Add fade-out effect before repeating driver animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,11 @@
         width: 100%;
         height: auto;
         display: block;
+        opacity: 1;
+        transition: opacity 2s ease;
+      }
+      .driver-overlay img.fade-out {
+        opacity: 0;
       }
       .driver-overlay img.animate {
         mask-image: repeating-linear-gradient(
@@ -336,9 +341,19 @@
         });
       }
 
+      function fadeAndAnimate() {
+        var img = document.getElementById('driver-img');
+        if (!img) return;
+        img.classList.add('fade-out');
+        setTimeout(function() {
+          img.classList.remove('fade-out');
+          startDriverAnimation();
+        }, 2000);
+      }
+
       document.addEventListener('DOMContentLoaded', function() {
         startDriverAnimation();
-        setInterval(startDriverAnimation, 30000);
+        setInterval(fadeAndAnimate, 30000);
       });
     </script>
   </head>


### PR DESCRIPTION
## Summary
- add opacity transition to driver image
- fade driver image before running animation every 30 seconds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453161c6648322a8fcbce9cfc62852