### PR TITLE
Prioritize driver animation over blend

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,8 +96,8 @@
         display: block;
         opacity: 1;
         transition: opacity 2s ease;
-        mask-image: radial-gradient(circle at center, black 85%, transparent 100%);
-        -webkit-mask-image: radial-gradient(circle at center, black 85%, transparent 100%);
+        mask-image: radial-gradient(circle at center, black 75%, transparent 100%);
+        -webkit-mask-image: radial-gradient(circle at center, black 75%, transparent 100%);
         mask-size: cover;
         -webkit-mask-size: cover;
       }
@@ -106,7 +106,6 @@
       }
       .driver-overlay img.animate {
         mask-image:
-          radial-gradient(circle at center, black 85%, transparent 100%),
           repeating-linear-gradient(
             to right,
             black 0,
@@ -115,7 +114,6 @@
             transparent 20px
           );
         -webkit-mask-image:
-          radial-gradient(circle at center, black 85%, transparent 100%),
           repeating-linear-gradient(
             to right,
             black 0,
@@ -123,20 +121,20 @@
             transparent 10px,
             transparent 20px
           );
-        mask-size: cover, 200% 100%;
-        -webkit-mask-size: cover, 200% 100%;
-        mask-position: center, -100% 0;
-        -webkit-mask-position: center, -100% 0;
+        mask-size: 200% 100%;
+        -webkit-mask-size: 200% 100%;
+        mask-position: -100% 0;
+        -webkit-mask-position: -100% 0;
         animation: maskSlideReverse 2s linear forwards;
       }
       @keyframes maskSlideReverse {
         from {
-          mask-position: center, -100% 0;
-          -webkit-mask-position: center, -100% 0;
+          mask-position: -100% 0;
+          -webkit-mask-position: -100% 0;
         }
         to {
-          mask-position: center, 0 0;
-          -webkit-mask-position: center, 0 0;
+          mask-position: 0 0;
+          -webkit-mask-position: 0 0;
         }
       }
       #loading-overlay {


### PR DESCRIPTION
## Summary
- make the edge mask use a 25% blend
- show the barrier-grid mask alone while animating

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684535cf46f0832292b827a462d2d2ee