### PR TITLE
Implement persistent Driver of the Week

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -63,6 +63,15 @@ function saveFrames(frames) {
   PropertiesService.getScriptProperties().setProperty('frames', JSON.stringify(frames));
 }
 
+function getDriverOfTheWeek() {
+  var props = PropertiesService.getScriptProperties();
+  return props.getProperty('driverOfWeek') || '';
+}
+
+function saveDriverOfTheWeek(name) {
+  PropertiesService.getScriptProperties().setProperty('driverOfWeek', name || '');
+}
+
 function getRandomQuote() {
   var props = PropertiesService.getScriptProperties();
   var quote = props.getProperty('weeklyQuote');

--- a/index.html
+++ b/index.html
@@ -141,12 +141,19 @@
         border-radius: 4px;
         z-index: 1000;
         pointer-events: auto;
+        width: 300px;
       }
 
       .driver-week input {
         width: 100%;
         margin-top: 4px;
         box-sizing: border-box;
+        font-size: 32px;
+        padding: 6px;
+      }
+
+      .driver-week label {
+        font-size: 32px;
       }
       .driver-overlay img {
         width: 100%;
@@ -237,6 +244,7 @@
         google.script.run.withSuccessHandler(updateWeather).getWeather();
         google.script.run.withSuccessHandler(loadFrames).getFrames();
         document.getElementById('add-frame').addEventListener('click', addFrame);
+        initDriver();
       }
 
       var frames = [];
@@ -290,6 +298,16 @@
       function loadFrames(data) {
         frames = data || [];
         frames.forEach(function(f, i) { createFrame(f, i); });
+      }
+
+      function initDriver() {
+        google.script.run.withSuccessHandler(function(name) {
+          document.getElementById('driver-name').value = name || '';
+        }).getDriverOfTheWeek();
+        var input = document.getElementById('driver-name');
+        input.addEventListener('input', function() {
+          google.script.run.saveDriverOfTheWeek(input.value);
+        });
       }
 
       function saveFrames() {


### PR DESCRIPTION
## Summary
- increase size of Driver of the Week label and text input
- persist the Driver of the Week name using Google Apps Script properties
- load and save the driver name client-side

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684593c18a388322a00dd92703bce61b