### PR TITLE
Implement driver-of-week tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,12 +148,12 @@
         width: 100%;
         margin-top: 4px;
         box-sizing: border-box;
-        font-size: 32px;
+        font-size: 64px;
         padding: 6px;
       }
 
       .driver-week label {
-        font-size: 32px;
+        font-size: 64px;
       }
       .driver-overlay img {
         width: 100%;
@@ -305,9 +305,16 @@
           document.getElementById('driver-name').value = name || '';
         }).getDriverOfTheWeek();
         var input = document.getElementById('driver-name');
-        input.addEventListener('input', function() {
+        function saveDriver() {
           google.script.run.saveDriverOfTheWeek(input.value);
+        }
+        input.addEventListener('keydown', function(e) {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            saveDriver();
+          }
         });
+        input.addEventListener('blur', saveDriver);
       }
 
       function saveFrames() {
@@ -370,11 +377,11 @@
         remRowBtn.className = 'sheet-btn';
         remRowBtn.textContent = 'Del Row';
         btnWrap.appendChild(remRowBtn);
-        div.appendChild(btnWrap);
 
         var sheetDiv = document.createElement('div');
         sheetDiv.className = 'spreadsheet';
         div.appendChild(sheetDiv);
+        div.appendChild(btnWrap);
 
         var resizer = document.createElement('div');
         resizer.className = 'resizer';


### PR DESCRIPTION
## Summary
- double the size of the Driver of the Week label and entry box
- save Driver of the Week server-side on Enter or blur
- move frame spreadsheet controls beneath each sheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845945587fc83228bca39c344bb3d1e