### PR TITLE
Fix exponent handling in spreadsheet formulas

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,7 @@
         if (val == null) return '';
         if (typeof val !== 'string' || val.charAt(0) !== '=') return val;
         var expr = val.substring(1);
+        expr = expr.replace(/\^/g, '**');
         expr = expr.replace(/([A-Z]+)(\d+)/g, function(_, col, row) {
           var colIdx = lettersToIndex(col);
           var rowIdx = parseInt(row, 10) - 1;


### PR DESCRIPTION
## Summary
- support caret `^` as an exponent operator by converting it to JavaScript `**`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459660129c8322972bd8b11ea00ec8