### PR TITLE
Reorder header buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,6 +844,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <div id="weather-temp"></div>
         <div id="weather-condition"></div>
         <button id="add-frame" class="add-frame-btn">Add Frame</button>
+        <button id="lock-toggle" class="lock-btn"></button>
         <div id="upload-container" class="upload-container">
           <button id="upload-toggle" class="add-frame-btn">Upload</button>
           <div id="upload-panel" class="upload-panel">
@@ -853,7 +854,6 @@ document.addEventListener('DOMContentLoaded', function() {
           <input type="file" id="logo-upload" accept="image/*" style="display:none;">
           <input type="file" id="driver-upload" accept="image/*" style="display:none;">
         </div>
-        <button id="lock-toggle" class="lock-btn"></button>
       </div>
     </div>
     <div id="viewing-area" class="viewing-area"></div>


### PR DESCRIPTION
## Summary
- move the lock toggle above the upload menu to show `Add Frame`, `Unlock`, `Upload` buttons from top to bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460545df988322a7f2706068d58530